### PR TITLE
Fix broken link by adding baseurl

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,3 +3,5 @@ description: Case studies and services in FDM 3-D printing, scan-to-CAD, and DfA
 theme: jekyll-theme-cayman           # free, clean, responsive
 show_downloads: false
 google_analytics:                    # you can add an ID later
+url: "https://pskelton0330.github.io"
+baseurl: "/Innovative-Design-Consepts"

--- a/index.md
+++ b/index.md
@@ -8,7 +8,7 @@ I save organisations time and money by redesigning obsolete parts, slashing lead
 and delivering custom solutions that don’t exist on the open market.
 
 ### Featured Case Studies
-* [Light-Pole Caps – $400 k saved](/2025/07/08/light-pole-caps.html)
+* [Light-Pole Caps – $400 k saved]({{ "/2025/07/08/light-pole-caps.html" | relative_url }})
 * 2nd Case Study
 * 3rd Case Study
 


### PR DESCRIPTION
## Summary
- set `url` and `baseurl` in `_config.yml`
- use `relative_url` for the case study link on the homepage

## Testing
- `./test/build.sh`


------
https://chatgpt.com/codex/tasks/task_e_686d32e3a0c8832cb99dc2b19b5150e7