### PR TITLE
Fix header layout and remove GitHub link

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -23,7 +23,7 @@
         {% for img in site.static_files %}{% if img.path contains '/assets/' and img.extname == '.png' %}<img src="{{ img.path | relative_url }}" alt="">{% endif %}{% endfor %}
       </div>
       {% if site.github.is_project_page %}
-        <a href="{{ site.github.repository_url }}" class="btn">View on GitHub</a>
+        <!-- GitHub repository link removed -->
       {% endif %}
       {% if site.show_downloads %}
         <a href="{{ site.github.zip_url }}" class="btn">Download .zip</a>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -23,6 +23,7 @@ body::before {
 .page-header {
   position: relative;
   overflow: hidden;
+  padding-bottom: 160px; /* ensure content clears the scrolling images */
 }
 
 #cad-scroller {


### PR DESCRIPTION
## Summary
- remove the `View on GitHub` button
- add bottom padding to the header so the scrolling image strip doesn't cover text

## Testing
- `bash test/build.sh`

------
https://chatgpt.com/codex/tasks/task_e_686da35a29d0832c9d6fc47f8992096d