### PR TITLE
Update typing overlay style

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -47,13 +47,13 @@ body::before {
 }
 #typing-overlay {
   position: absolute;
-  top: 50%;
   left: 50%;
-  transform: translate(-50%, -50%);
+  bottom: 75px;
+  transform: translateX(-50%);
   font-family: monospace;
   font-size: 2rem;
-  color: #fff;
+  color: #00ff00;
   white-space: nowrap;
   pointer-events: none;
-  z-index: 1;
+  z-index: 2;
 }


### PR DESCRIPTION
## Summary
- tweak the typing overlay style to use bright green text
- move the text down so it's on top of the slideshow
- ensure it renders above the image scroller

## Testing
- `./test/build.sh`

------
https://chatgpt.com/codex/tasks/task_e_686e368169d4832c9a63dcea8b6a419a