### PR TITLE
Fix HVAC case study layout

### DIFF
--- a/_posts/2025-07-06-obsolete-hvac-linkage.md
+++ b/_posts/2025-07-06-obsolete-hvac-linkage.md
@@ -1,6 +1,6 @@
 ---
 title: "Chiller Valve Coupler: 98 % Cost-Cut, Same-Day Spares for Legacy HVAC"
-layout: post
+layout: default
 ---
 
 ![Carbon-fiber-nylon replacement coupler](/assets/img/hvac-coupler.jpg)

--- a/index.md
+++ b/index.md
@@ -11,7 +11,7 @@ and delivering custom solutions that don’t exist on the open market.
 ### Featured Case Studies
 * [Light-Pole Caps – $400 k saved]({{ "/2025/07/08/light-pole-caps.html" | relative_url }})
 * [RFID-Bypass Adapter Cuts Soap Costs $500 k/yr]({{ "/2025/07/07/rfid-bypass-adapter.html" | relative_url }})
-* [Obsolete HVAC Linkage Printed in 45 min]({{ "/2025/07/06/obsolete-hvac-linkage.html" | relative_url }})
+* [Chiller Valve Coupler: 98 % Cost-Cut, Same-Day Spares for Legacy HVAC]({{ "/2025/07/06/obsolete-hvac-linkage.html" | relative_url }})
 
 ### Services
 * Reverse-engineering & CAD model creation


### PR DESCRIPTION
## Summary
- use default layout for obsolete HVAC case study so the style matches
- update homepage link text to match the case study title

## Testing
- `bash test/build.sh` *(fails: jekyll command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e72319650832c867b85e1793b4dcc