### PR TITLE
Add bundler setup scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+_site/
+.DS_Store
+
+vendor/
+.bundle/

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem 'jekyll', '~> 4.4'
+# Theme used by the site
+
+gem 'jekyll-theme-cayman'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # 3D-Innovation-and-Design-Concepts
 
+## Setup
+Run `./test/setup.sh` to install the Ruby gems needed to build the site.
+
 ## Testing
 Run `./test/build.sh` to build the site using Jekyll. The script exits with a non-zero status if the build fails.

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -25,6 +25,10 @@
         {% for img in scroller_images %}<img src="{{ img.path | relative_url }}" alt="CAD render">{% endfor %}
         {% for img in scroller_images %}<img src="{{ img.path | relative_url }}" alt="CAD render">{% endfor %}
       </div>
+      <nav class="site-nav">
+        <a href="{{ '/' | relative_url }}">Home</a>
+        <a href="{{ '/about.html' | relative_url }}">About Me</a>
+      </nav>
       {% if site.github.is_project_page %}
         <!-- GitHub repository link removed -->
       {% endif %}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -62,3 +62,13 @@ body::before {
   pointer-events: none;
   z-index: 2;
 }
+
+.site-nav {
+  margin-top: 1rem;
+}
+
+.site-nav a {
+  color: #fff;
+  margin-right: 1rem;
+  text-decoration: none;
+}

--- a/test/build.sh
+++ b/test/build.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 set -e
-jekyll build
+
+bundle exec jekyll build

--- a/test/setup.sh
+++ b/test/setup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+# Install bundler if not present
+if ! command -v bundle >/dev/null; then
+  gem install bundler
+fi
+
+bundle install --path vendor/bundle


### PR DESCRIPTION
## Summary
- provide Gemfile specifying Jekyll and theme
- ignore build artifacts in `.gitignore`
- add `test/setup.sh` to install Ruby gems
- run `jekyll` via Bundler in `test/build.sh`
- document setup step in README

## Testing
- `bash test/setup.sh`
- `bash test/build.sh`

------
https://chatgpt.com/codex/tasks/task_e_686e7cc9f8b0832ca95d048a4c237386