### PR TITLE
Add About Me link to contact section

### DIFF
--- a/index.md
+++ b/index.md
@@ -23,4 +23,5 @@ and delivering custom solutions that don't exist on the open market.
 * Innovative solution consulting
 
 **Contact:** pskelton0330@gmail.com
+[About Me](about.html)
 


### PR DESCRIPTION
## Summary
- add an About Me link after the contact email on the homepage

## Testing
- `bash test/setup.sh`
- `bash test/build.sh` *(fails: Liquid syntax error in site)*

------
https://chatgpt.com/codex/tasks/task_e_686fd2111060832c88bf597907c26c88