### PR TITLE
Remove CAD slideshow

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,10 +20,6 @@
       <h2 class="project-name">{{ page.title | default: site.title | default: site.github.repository_name }}</h2>
       <h3 class="project-tagline">{{ page.description | default: site.description | default: site.github.project_tagline }}</h3>
       <div id="typing-overlay"></div>
-    <div id="cad-scroller">
-      <img src="{{ '/assets/img/background.png' | relative_url }}" alt="CAD render">
-      <img src="{{ '/assets/img/light-cap.png' | relative_url }}" alt="CAD render">
-    </div>
       <nav class="site-nav">
         <a href="{{ '/' | relative_url }}">Home</a>
         <a href="{{ '/about.html' | relative_url }}">About Me</a>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -31,25 +31,6 @@ body::before {
   font-size: 2.5rem;
 }
 
-#cad-scroller {
-  display: flex;
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  height: 150px;
-  width: max-content;
-  animation: cad-scroll 40s linear infinite;
-}
-
-#cad-scroller img {
-  height: 100%;
-  margin-right: 1rem;
-}
-
-@keyframes cad-scroll {
-  from { transform: translateX(0); }
-  to { transform: translateX(-50%); }
-}
 #typing-overlay {
   position: absolute;
   left: 50%;


### PR DESCRIPTION
## Summary
- remove CAD slideshow in default layout
- drop unused CSS for `#cad-scroller`

## Testing
- `./test/build.sh`

------
https://chatgpt.com/codex/tasks/task_e_686fe2f3625c832cae85a7dceb58c915