### PR TITLE
Brighten green heading color

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -72,3 +72,12 @@ body::before {
   margin-right: 1rem;
   text-decoration: none;
 }
+
+.main-content h1,
+.main-content h2,
+.main-content h3,
+.main-content h4,
+.main-content h5,
+.main-content h6 {
+  color: #00ff00; /* bright green for better visibility */
+}


### PR DESCRIPTION
## Summary
- brighten heading color for improved contrast

## Testing
- `./test/setup.sh`
- `./test/build.sh`


------
https://chatgpt.com/codex/tasks/task_e_686fe374c474832c9d56d6d78f11ba59