### PR TITLE
Correct light pole cap case study title on homepage

### DIFF
--- a/index.md
+++ b/index.md
@@ -10,7 +10,7 @@ and delivering custom solutions that don't exist on the open market.
 [About Me](about.html)
 
 ### Featured Case Studies
-* [Light-Pole Caps – $400 k saved]({{ "/2025/07/08/light-pole-caps.html" | relative_url }})
+* [Tailored Retrofit: How 3D Printing Prevented a $400K Expense]({{ "/2025/07/08/light-pole-caps.html" | relative_url }})
 * [RFID-Bypass Adapter Cuts Soap Costs $500 k/yr]({{ "/2025/07/07/rfid-bypass-adapter.html" | relative_url }})
 * [Chiller Valve Coupler: 98 % Cost-Cut, Same-Day Spares for Legacy HVAC]({{ "/2025/07/06/obsolete-hvac-linkage.html" | relative_url }})
 


### PR DESCRIPTION
## Summary
- update the light pole cap case study title on the home page to match the title used in the case study

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_687000076800832cade213ac0cb26f6d