### PR TITLE
Fix soap adapter case study title

### DIFF
--- a/index.md
+++ b/index.md
@@ -10,7 +10,7 @@ and delivering custom solutions that don't exist on the open market.
 
 ### Featured Case Studies
 * [Tailored Retrofit: How 3D Printing Prevented a $400K Expense]({{ "/2025/07/08/light-pole-caps.html" | relative_url }})
-* [RFID-Bypass Adapter Cuts Soap Costs $500 k/yr]({{ "/2025/07/07/rfid-bypass-adapter.html" | relative_url }})
+* [Smart Adaptation: 3D Printing Solutions for Facility Maintenance Savings]({{ "/2025/07/07/rfid-bypass-adapter.html" | relative_url }})
 * [Chiller Valve Coupler: 98 % Cost-Cut, Same-Day Spares for Legacy HVAC]({{ "/2025/07/06/obsolete-hvac-linkage.html" | relative_url }})
 
 ### Services


### PR DESCRIPTION
## Summary
- rename the soap adapter case study title on homepage

## Testing
- `bash test/setup.sh`
- `bash test/build.sh`

------
https://chatgpt.com/codex/tasks/task_e_68703a8ec7c0832cb570f72d3a6dd5e7