### PR TITLE
Add Google fonts and font styles

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,0 +1,8 @@
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Clash+Display:wght@600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="{{ '/assets/css/tailwind.css' | relative_url }}">
+<style>
+  html { font-family: 'Inter', sans-serif; }
+  h1, h2, h3 { font-family: 'Clash Display', sans-serif; }
+</style>


### PR DESCRIPTION
## Summary
- add a new `_includes/head.html`
- include Google Fonts Inter and Clash Display
- set default and heading font families

## Testing
- `bash test/build.sh`

------
https://chatgpt.com/codex/tasks/task_e_6870e5a18820832cb2dd2050a3241fdd